### PR TITLE
[nrf noup]: using ZEPHYR_NRF_MODULE_DIR for partition manager inclusion

### DIFF
--- a/cmake/app/boilerplate.cmake
+++ b/cmake/app/boilerplate.cmake
@@ -585,9 +585,9 @@ set_property(TARGET app PROPERTY ARCHIVE_OUTPUT_DIRECTORY app)
 
 add_subdirectory(${ZEPHYR_BASE} ${__build_dir})
 
-include(${ZEPHYR_BASE}/../nrf/cmake/partition_manager.cmake
-  OPTIONAL
-  )
+if(ZEPHYR_NRF_MODULE_DIR)
+  include(${ZEPHYR_NRF_MODULE_DIR}/cmake/partition_manager.cmake)
+endif()
 
 # Link 'app' with the Zephyr interface libraries.
 #


### PR DESCRIPTION
Now using ZEPHYR_NRF_MODULE_DIR when including partition manager cmake
file.
The previous OPTIONAL loading of partition manager would include the
file if the nrf folder was present regardless of whether nrf is part
of the project or not.

This means a stray nrf folder causes unintended side effects when using
sdk-zephyr as manifest repository.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>